### PR TITLE
Fix commands to add `asdf` plugins

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -30,8 +30,8 @@ order to have a better control over installes versions:
 
 * Install system-wide required binaries by running `brew bundle`
 * Install the following [asdf-vm](https://asdf-vm.com/) plugins by running:
-    * `asdf plugin-add kubectl`
-    * `asdf plugin-add helm`
+    * `asdf plugin add kubectl`
+    * `asdf plugin add helm`
 * Finally, install versioned dependencies with `asdf install`
 * Git clone [https://github.com/masci/k8s101/](https://github.com/masci/k8s101/) and perform the exercises from the root of the repo
 


### PR DESCRIPTION
`asdf` introduced lots of breaking changes with the `0.16.0` as outlined in [here](https://asdf-vm.com/guide/upgrading-to-v0-16.html#hyphenated-commands-have-been-removed).

This fixed adding the required plugins.